### PR TITLE
Remoção de vértices e arestas

### DIFF
--- a/examples/adjacency_list_operations.rs
+++ b/examples/adjacency_list_operations.rs
@@ -1,5 +1,3 @@
-use std::fs::DirEntry;
-
 use graphs_algorithms::{Graph, UndirectedGraph, graphs::AdjacencyList};
 
 fn print_list(list: &AdjacencyList) {
@@ -7,7 +5,8 @@ fn print_list(list: &AdjacencyList) {
         println!("{}: {:?}", i, neighbors);
     }
 }
-fn main() {
+
+fn digraph_add() {
     println!("Digraph!");
     let mut directed_g = AdjacencyList(vec![vec![1, 2], vec![0], vec![0]]);
 
@@ -30,7 +29,26 @@ fn main() {
     println!("Edge 3 - 3");
     directed_g.add_edge(3, 3);
     print_list(&directed_g);
+}
 
+fn digraph_delete() {
+    println!("Digraph!");
+
+    let mut directed_g =
+        AdjacencyList(vec![vec![3], vec![], vec![1], vec![1, 4], vec![5], vec![2]]);
+
+    print_list(&directed_g);
+
+    println!("Delete edge 3 -> 1");
+    directed_g.remove_edge(3, 1);
+    print_list(&directed_g);
+
+    println!("Delete Node 2");
+    directed_g.remove_node(2);
+    print_list(&directed_g);
+}
+
+fn undirected_graph_add() {
     println!("Undirected graph!");
     let mut undirected_g = AdjacencyList(vec![vec![1, 2], vec![0], vec![0]]);
 
@@ -53,4 +71,30 @@ fn main() {
     println!("Edge 3 - 3");
     undirected_g.add_undirected_edge(3, 3);
     print_list(&undirected_g);
+}
+
+fn undirected_graph_delete() {
+    println!("Undirected graph!");
+
+    let mut undirected_g = AdjacencyList(vec![
+        vec![1, 2],
+        vec![0, 2],
+        vec![0, 1, 3, 4],
+        vec![2],
+        vec![2],
+    ]);
+
+    print_list(&undirected_g);
+
+    println!("Delete edge 2 -> 1");
+    undirected_g.remove_undirected_edge(2, 1);
+    print_list(&undirected_g);
+
+    println!("Delete Node 2");
+    undirected_g.remove_node(2);
+    print_list(&undirected_g);
+}
+
+fn main() {
+    undirected_graph_delete();
 }

--- a/examples/adjacency_matrix_operations.rs
+++ b/examples/adjacency_matrix_operations.rs
@@ -12,7 +12,7 @@ fn print_matrix(m: &AdjacencyMatrix) {
     }
 }
 
-fn test_digraph_create_and_add() {
+fn digraph_create_and_add() {
     println!("Digraph!");
     let mut directed_m = AdjacencyMatrix(vec![vec![0, 1, 1], vec![0, 0, 0], vec![0, 1, 0]]);
 
@@ -33,7 +33,7 @@ fn test_digraph_create_and_add() {
     print_matrix(&directed_m);
 }
 
-fn test_undirected_graph_create_and_add() {
+fn undirected_graph_create_and_add() {
     println!("Undirected graph!");
     let mut undirected_m = AdjacencyMatrix(vec![
         vec![0, 0, 0, 1, 0, 0],
@@ -49,7 +49,7 @@ fn test_undirected_graph_create_and_add() {
     print_matrix(&undirected_m);
 }
 
-fn test_digraph_delete() {
+fn digraph_delete() {
     let mut m = AdjacencyMatrix(vec![
         vec![0, 1, 0, 0, 0],
         vec![0, 0, 1, 0, 1],
@@ -67,6 +67,27 @@ fn test_digraph_delete() {
     print_matrix(&m);
 }
 
+fn undirected_graph_delete() {
+    println!("Undirected graph!");
+    let mut undirected_m = AdjacencyMatrix(vec![
+        vec![0, 0, 0, 1, 0, 0],
+        vec![0, 0, 1, 1, 0, 0],
+        vec![0, 1, 0, 1, 0, 0],
+        vec![1, 1, 1, 0, 1, 1],
+        vec![0, 0, 0, 1, 0, 1],
+        vec![0, 0, 0, 1, 1, 0],
+    ]);
+    print_matrix(&undirected_m);
+
+    println!("Delete edge 3 - 4 ");
+    undirected_m.remove_undirected_edge(3, 4);
+    print_matrix(&undirected_m);
+
+    println!("Delete node 3");
+    undirected_m.remove_node(3);
+    print_matrix(&undirected_m);
+}
+
 fn main() {
-    test_digraph_delete();
+    undirected_graph_delete();
 }

--- a/examples/adjacency_matrix_test.rs
+++ b/examples/adjacency_matrix_test.rs
@@ -11,7 +11,8 @@ fn print_matrix(m: &AdjacencyMatrix) {
         println!();
     }
 }
-fn main() {
+
+fn test_digraph_create_and_add() {
     println!("Digraph!");
     let mut directed_m = AdjacencyMatrix(vec![vec![0, 1, 1], vec![0, 0, 0], vec![0, 1, 0]]);
 
@@ -30,7 +31,9 @@ fn main() {
     println!("Edge 0 -> 0");
     directed_m.add_edge(0, 0);
     print_matrix(&directed_m);
+}
 
+fn test_undirected_graph_create_and_add() {
     println!("Undirected graph!");
     let mut undirected_m = AdjacencyMatrix(vec![
         vec![0, 0, 0, 1, 0, 0],
@@ -44,4 +47,26 @@ fn main() {
     println!("Edge 0 - 5");
     undirected_m.add_undirected_edge(0, 5);
     print_matrix(&undirected_m);
+}
+
+fn test_digraph_delete() {
+    let mut m = AdjacencyMatrix(vec![
+        vec![0, 1, 0, 0, 0],
+        vec![0, 0, 1, 0, 1],
+        vec![0, 0, 0, 0, 0],
+        vec![0, 0, 1, 0, 0],
+        vec![0, 0, 1, 0, 0],
+    ]);
+    print_matrix(&m);
+    println!("Delete edge 3 -> 2");
+    m.remove_edge(3, 2);
+    print_matrix(&m);
+
+    println!("Delete node 2");
+    m.remove_node(2);
+    print_matrix(&m);
+}
+
+fn main() {
+    test_digraph_delete();
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -208,6 +208,11 @@ pub trait UndirectedGraph<Node: Copy + Eq + Hash>: Graph<Node> {
         self.add_edge(m, n);
     }
 
+    fn remove_undirected_edge(&mut self, n: Node, m: Node) {
+        self.remove_edge(n, m);
+        self.remove_edge(m, n);
+    }
+
     fn dfs_tree_and_back_edges(&self, start_nodes: &[Node]) -> impl Iterator<Item = Edge<Node>>
     where
         Self: Sized,


### PR DESCRIPTION
Resolução da Issue #10 
- Implementação de `remove_edge` e `remove_node` para `AdjacencyMatrix`
- Implementação a nível de trait `UndirectedGraph` para função `remove_undirected_edge`
- Elaboração de testes automatizados de remoção tanto para `AdjacencyMatrix` quanto `AdjacencyList`
- Implementação da função `size` para `AdjacencyMatrix` para fins de verificações nos testes automatizados; a implementação em `AdjacencyList` não foi alterada pois há uma Issue a parte para essas funções.