### PR TITLE
Refatora iterador da Busca em Profundidade

### DIFF
--- a/benches/dfs_bench.rs
+++ b/benches/dfs_bench.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use graphs_algorithms::Graph;
 use graphs_algorithms::graphs::{AdjacencyList, AdjacencyMatrix};
+use graphs_algorithms::{DfsEvent, Graph};
 
 fn create_adjacency_matrix(size: usize) -> AdjacencyMatrix {
     let mut matrix = vec![vec![0; size]; size];
@@ -33,7 +33,13 @@ fn bench_dfs_list(c: &mut Criterion) {
         c.bench_with_input(
             BenchmarkId::new("dfs_adjacency_list", size),
             &size,
-            |b, _| b.iter(|| list.dfs(0).for_each(|_| ())),
+            |b, _| {
+                b.iter(|| {
+                    list.dfs(0)
+                        .filter(|e| matches!(e, DfsEvent::Discover(_, _)))
+                        .for_each(|_| ())
+                })
+            },
         );
     }
 }

--- a/examples/classify_edges_graph.rs
+++ b/examples/classify_edges_graph.rs
@@ -30,7 +30,17 @@ fn main() {
             _ => panic!(),
         }
     }
-    for e in digraph.classify_edges(0) {
+    let mut iter = digraph.classify_edges(0);
+    for e in &mut iter {
+        match e {
+            Edge::Tree(v, u) => println!("Tree: {} -> {}", m(v), m(u)),
+            Edge::Back(v, u) | Edge::ParentBack(v, u) => println!("Back: {} -> {}", m(v), m(u)),
+            Edge::Foward(v, u) => println!("Foward: {} -> {}", m(v), m(u)),
+            Edge::Cross(v, u) => println!("Cross: {} -> {}", m(v), m(u)),
+        }
+    }
+    iter.new_start(8);
+    for e in &mut iter {
         match e {
             Edge::Tree(v, u) => println!("Tree: {} -> {}", m(v), m(u)),
             Edge::Back(v, u) | Edge::ParentBack(v, u) => println!("Back: {} -> {}", m(v), m(u)),

--- a/examples/classify_edges_graph.rs
+++ b/examples/classify_edges_graph.rs
@@ -1,7 +1,9 @@
+use graphs_algorithms::Edge;
+use graphs_algorithms::Graph;
 use graphs_algorithms::graphs::AdjacencyList;
 
 fn main() {
-    let _digraph = AdjacencyList(vec![
+    let digraph = AdjacencyList(vec![
         vec![1, 2, 7],
         vec![3],
         vec![],
@@ -13,7 +15,7 @@ fn main() {
         vec![4, 9],
         vec![],
     ]);
-    fn _m(i: usize) -> char {
+    fn m(i: usize) -> char {
         match i {
             0 => 's',
             1 => 'a',
@@ -28,5 +30,12 @@ fn main() {
             _ => panic!(),
         }
     }
-    todo!()
+    for e in digraph.classify_edges(0) {
+        match e {
+            Edge::Tree(v, u) => println!("Tree: {} -> {}", m(v), m(u)),
+            Edge::Back(v, u) | Edge::ParentBack(v, u) => println!("Back: {} -> {}", m(v), m(u)),
+            Edge::Foward(v, u) => println!("Foward: {} -> {}", m(v), m(u)),
+            Edge::Cross(v, u) => println!("Cross: {} -> {}", m(v), m(u)),
+        }
+    }
 }

--- a/examples/classify_edges_graph.rs
+++ b/examples/classify_edges_graph.rs
@@ -1,9 +1,7 @@
-use graphs_algorithms::Edge;
-use graphs_algorithms::Graph;
 use graphs_algorithms::graphs::AdjacencyList;
 
 fn main() {
-    let digraph = AdjacencyList(vec![
+    let _digraph = AdjacencyList(vec![
         vec![1, 2, 7],
         vec![3],
         vec![],
@@ -15,7 +13,7 @@ fn main() {
         vec![4, 9],
         vec![],
     ]);
-    fn m(i: usize) -> char {
+    fn _m(i: usize) -> char {
         match i {
             0 => 's',
             1 => 'a',
@@ -30,12 +28,5 @@ fn main() {
             _ => panic!(),
         }
     }
-    for e in digraph.dfs_edges(&[0, 8]) {
-        match e {
-            Edge::Tree((v, u)) => println!("Tree: {} -> {}", m(v), m(u)),
-            Edge::Back((v, u)) | Edge::ParentBack((v, u)) => println!("Back: {} -> {}", m(v), m(u)),
-            Edge::Foward((v, u)) => println!("Foward: {} -> {}", m(v), m(u)),
-            Edge::Cross((v, u)) => println!("Cross: {} -> {}", m(v), m(u)),
-        }
-    }
+    todo!()
 }

--- a/examples/classify_edges_undirected_graph.rs
+++ b/examples/classify_edges_undirected_graph.rs
@@ -1,9 +1,11 @@
 use core::panic;
 
+use graphs_algorithms::Edge;
+use graphs_algorithms::UndirectedGraph;
 use graphs_algorithms::graphs::AdjacencyList;
 
 fn main() {
-    let _undirected_graph = AdjacencyList(vec![
+    let undirected_graph = AdjacencyList(vec![
         vec![1, 7, 2],
         vec![3, 4, 0],
         vec![0],
@@ -15,7 +17,7 @@ fn main() {
         vec![7, 9],
         vec![8],
     ]);
-    fn _m(i: usize) -> char {
+    fn m(i: usize) -> char {
         match i {
             0 => 's',
             1 => 'a',
@@ -28,6 +30,13 @@ fn main() {
             8 => 'h',
             9 => 'i',
             _ => panic!(),
+        }
+    }
+    for e in undirected_graph.classify_undirected_edges(0) {
+        match e {
+            Edge::Tree(v, u) => println!("Tree: {} -> {}", m(v), m(u)),
+            Edge::Back(v, u) => println!("Back: {} -> {}", m(v), m(u)),
+            _ => panic!("should not get here"),
         }
     }
 }

--- a/examples/classify_edges_undirected_graph.rs
+++ b/examples/classify_edges_undirected_graph.rs
@@ -1,11 +1,9 @@
 use core::panic;
 
-use graphs_algorithms::Edge;
-use graphs_algorithms::UndirectedGraph;
 use graphs_algorithms::graphs::AdjacencyList;
 
 fn main() {
-    let undirected_graph = AdjacencyList(vec![
+    let _undirected_graph = AdjacencyList(vec![
         vec![1, 7, 2],
         vec![3, 4, 0],
         vec![0],
@@ -17,7 +15,7 @@ fn main() {
         vec![7, 9],
         vec![8],
     ]);
-    fn m(i: usize) -> char {
+    fn _m(i: usize) -> char {
         match i {
             0 => 's',
             1 => 'a',
@@ -30,13 +28,6 @@ fn main() {
             8 => 'h',
             9 => 'i',
             _ => panic!(),
-        }
-    }
-    for e in undirected_graph.dfs_tree_and_back_edges(&[0]) {
-        match e {
-            Edge::Tree((v, u)) => println!("Tree: {} -> {}", m(v), m(u)),
-            Edge::Back((v, u)) => println!("Back: {} -> {}", m(v), m(u)),
-            _ => panic!("Should not get here"),
         }
     }
 }

--- a/examples/node_degree.rs
+++ b/examples/node_degree.rs
@@ -1,0 +1,32 @@
+use graphs_algorithms::Graph;
+use graphs_algorithms::graphs::{AdjacencyList, AdjacencyMatrix, IncidenceMatrix};
+
+fn main() {
+    let graph = AdjacencyList(vec![vec![1], vec![0, 2], vec![1]]);
+
+    println!("Grau de cada vértice:");
+    for i in 0..graph.order() {
+        println!("Vértice {}: {}", i, graph.node_degree(i));
+    }
+
+    let matrix = AdjacencyMatrix(vec![vec![0, 1, 1], vec![1, 0, 1], vec![1, 1, 0]]);
+
+    println!("Grau de cada vértice:");
+    for i in 0..matrix.order() {
+        println!("Vértice {}: {}", i, matrix.node_degree(i));
+    }
+
+    let adjacency_matrix = AdjacencyMatrix(vec![
+        vec![0, 1, 1], // 0 conectado a 1 e 2
+        vec![1, 0, 0], // 1 conectado a 0
+        vec![1, 0, 0], // 2 conectado a 0
+    ]);
+
+    // Gerando a matriz de incidência a partir da matriz de adjacência
+    let incidence_matrix = IncidenceMatrix::from_adjacency_matrix(&adjacency_matrix);
+
+    println!("Grau de cada vértice (Matriz de Incidência):");
+    for i in 0..matrix.order() {
+        println!("Vértice {}: {}", i, incidence_matrix.node_degree(i));
+    }
+}

--- a/src/adjacency_list.rs
+++ b/src/adjacency_list.rs
@@ -545,4 +545,14 @@ mod tests {
         assert!(list.has_edge(0, 3));
         assert!(list.connected());
     }
+
+    #[test]
+    fn node_degree_adjacency_list() {
+        // Grafo: 0 ── 1 ── 2
+        let graph = AdjacencyList(vec![vec![1], vec![0, 2], vec![1]]);
+
+        assert_eq!(graph.node_degree(0), 1);
+        assert_eq!(graph.node_degree(1), 2);
+        assert_eq!(graph.node_degree(2), 1);
+    }
 }

--- a/src/adjacency_list.rs
+++ b/src/adjacency_list.rs
@@ -1,8 +1,8 @@
 use crate::Graph;
-use crate::graph::UndirectedGraph;
+use crate::graph::{DfsEvent, UndirectedGraph};
 use crate::graphs::{AdjacencyMatrix, IncidenceMatrix};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AdjacencyList(pub Vec<Vec<usize>>);
 
 impl AdjacencyList {
@@ -122,7 +122,12 @@ impl Graph<usize> for AdjacencyList {
     // TODO: Only working for undirected graphs...
     fn connected(&self) -> bool {
         for i in 0..self.order() {
-            if self.dfs(i).count() != self.order() {
+            if self
+                .dfs(i)
+                .filter(|event| matches!(event, DfsEvent::Discover(_, _)))
+                .count()
+                != self.order()
+            {
                 return false;
             }
         }

--- a/src/adjacency_list.rs
+++ b/src/adjacency_list.rs
@@ -119,7 +119,12 @@ impl Graph<usize> for AdjacencyList {
         }
     }
 
-    // TODO: Only working for undirected graphs...
+    fn biparted(&self) -> bool {
+        todo!()
+    }
+}
+
+impl UndirectedGraph<usize> for AdjacencyList {
     fn connected(&self) -> bool {
         for i in 0..self.order() {
             if self
@@ -134,17 +139,10 @@ impl Graph<usize> for AdjacencyList {
         true
     }
 
-    fn biparted(&self) -> bool {
-        todo!()
-    }
-
-    #[allow(unreachable_code)]
     fn biconnected_components(&self) -> &[Vec<usize>] {
         todo!();
     }
 }
-
-impl UndirectedGraph<usize> for AdjacencyList {}
 
 #[cfg(test)]
 mod tests {

--- a/src/adjacency_list.rs
+++ b/src/adjacency_list.rs
@@ -110,12 +110,12 @@ impl Graph<usize> for AdjacencyList {
         }
     }
 
-    type Neighbors<'a> = Box<dyn Iterator<Item = usize> + 'a>;
+    type Neighbors<'a> = std::iter::Copied<std::slice::Iter<'a, usize>>;
 
     fn neighbors<'a>(&'a self, n: usize) -> Self::Neighbors<'a> {
         match self.0.get(n) {
-            Some(edges) => Box::new(edges.iter().copied()),
-            None => Box::new(std::iter::empty()),
+            Some(edges) => edges.iter().copied(),
+            None => [].iter().copied(),
         }
     }
 

--- a/src/adjacency_matrix.rs
+++ b/src/adjacency_matrix.rs
@@ -133,6 +133,7 @@ impl Graph<usize> for AdjacencyMatrix {
         self.0.len()
     }
 
+    // FIXME: There is edge duplication in undirected graphs.
     fn size(&self) -> usize {
         let mut stack: Vec<(usize, usize)> = Vec::new();
 
@@ -219,18 +220,10 @@ impl Graph<usize> for AdjacencyMatrix {
         }
     }
 
-    fn connected(&self) -> bool {
-        todo!()
-    }
-
-    fn biconnected_components(&self) -> &[Vec<usize>] {
-        todo!()
-    }
-
     fn biparted(&self) -> bool {
         todo!()
     }
-
+    
     fn node_degree(&self, node: usize) -> usize {
         if let Some(row) = self.0.get(node) {
             row.iter().filter(|&&val| val != 0).count()
@@ -240,7 +233,15 @@ impl Graph<usize> for AdjacencyMatrix {
     }
 }
 
-impl UndirectedGraph<usize> for AdjacencyMatrix {}
+impl UndirectedGraph<usize> for AdjacencyMatrix {
+    fn connected(&self) -> bool {
+        todo!()
+    }
+
+    fn biconnected_components(&self) -> &[Vec<usize>] {
+        todo!()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/adjacency_matrix.rs
+++ b/src/adjacency_matrix.rs
@@ -223,7 +223,7 @@ impl Graph<usize> for AdjacencyMatrix {
     fn biparted(&self) -> bool {
         todo!()
     }
-    
+
     fn node_degree(&self, node: usize) -> usize {
         if let Some(row) = self.0.get(node) {
             row.iter().filter(|&&val| val != 0).count()

--- a/src/adjacency_matrix.rs
+++ b/src/adjacency_matrix.rs
@@ -230,6 +230,14 @@ impl Graph<usize> for AdjacencyMatrix {
     fn biparted(&self) -> bool {
         todo!()
     }
+
+    fn node_degree(&self, node: usize) -> usize {
+        if let Some(row) = self.0.get(node) {
+            row.iter().filter(|&&val| val != 0).count()
+        } else {
+            0
+        }
+    }
 }
 
 impl UndirectedGraph<usize> for AdjacencyMatrix {}
@@ -495,5 +503,17 @@ mod tests {
         assert!(m.size() == 3);
         assert!(!m.has_edge(2, 4));
         assert!(!m.has_edge(1, 4));
+    }
+
+    #[test]
+    fn node_degree_adjacency_matrix() {
+        // Grafo: 0 ─ 1
+        //        │ /
+        //        2
+        let matrix = AdjacencyMatrix(vec![vec![0, 1, 1], vec![1, 0, 1], vec![1, 1, 0]]);
+
+        assert_eq!(matrix.node_degree(0), 2);
+        assert_eq!(matrix.node_degree(1), 2);
+        assert_eq!(matrix.node_degree(2), 2);
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -75,6 +75,45 @@ pub trait UndirectedGraph<Node: Copy + Eq + Hash>: Graph<Node> {
     }
 }
 
+/// Represents an event that occurs during a depth-first search (DFS) traversal.
+///
+/// This enum is used to describe the different types of events that can be
+/// encountered while performing DFS on a graph. It is generic over the `Node`
+/// type, which represents the nodes in the graph.
+///
+/// # Variants
+/// - `Discover(Node, Option<Node>)`: Indicates that a node has been discovered for the first time.
+///   The `Option<Node>` represents the parent node in the DFS tree (`None` for the start node).
+/// - `Finish(Node)`: Indicates that all descendants of a node have been visited and the node is finished.
+/// - `NonTreeEdge(Node, Node)`: Indicates that a non-tree edge (back, forward, or cross edge) is found
+///   from the first node to the second node.
+#[derive(Debug)]
+pub enum DfsEvent<Node> {
+    Discover(Node, Option<Node>),
+    Finish(Node),
+    NonTreeEdge(Node, Node),
+}
+
+/// Represents a iterator over a depth-first-search (DFS) traversal.
+///
+/// The iteration yields a `DfsEvent<Node>` over each instasse of `next`.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// // Should print every event that happens
+/// // when you traverse the graph starting from node `u`.
+/// let mut iter = graph.dfs(u);
+/// for e in iter {
+///     println!("{:?}", e);
+/// }
+///
+/// // Should print every event that's a node discovery.
+/// let mut iter = graph.dfs(0);
+/// for e in iter.filter(|e| matches!(e, DfsEvent::Discover(_))) {
+///     println!("{:?}", e);
+/// }
+/// ```
 pub struct DfsIter<'a, Node, G>
 where
     G: Graph<Node>,
@@ -97,20 +136,29 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> DfsIter<'a, Node, G> {
         }
     }
 
+    /// Sets the `start_node` field of a `DfsIter` manually.
+    ///
+    /// This enables starting another DFS while maintaing the inner parts of the iterator
+    /// initialized, like the `visited` dictionary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // Initializes a iterator to search starting from node `u`.
+    /// let mut iter = graph.dfs(u);
+    /// for e in &mut iter {
+    ///     println!("{e}");
+    /// }
+    ///
+    /// // Does the same for `v`.
+    /// iter.new_start(v);
+    /// for e in &mut iter {
+    ///     println!("{e}");
+    /// }
+    /// ```
     pub fn new_start(&mut self, start: Node) {
         self.start_node = Some(start)
     }
-}
-
-#[derive(Debug)]
-pub enum DfsEvent<Node> {
-    /// A node is discovered for the first time.
-    /// The Option<Node> is the parent in the DFS tree (None for the start Node).
-    Discover(Node, Option<Node>),
-    /// All descendants of a node have been visited.
-    Finish(Node),
-    /// A non-tree edge is found from the first node to the second.
-    NonTreeEdge(Node, Node),
 }
 
 impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for DfsIter<'a, Node, G> {
@@ -176,6 +224,19 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for BfsIter<'a, Node, 
     }
 }
 
+/// Represents the classification of an edge in a graph during a depth-first search (DFS).
+///
+/// This enum is used to categorize edges based on the DFS traversal. It is generic
+/// over the `Node` type, which represents the nodes in the graph. The classification
+/// is based on the relationship between the two nodes connected by the edge in the DFS tree.
+///
+/// # Variants
+/// - `Tree(u, v)`: An edge from a parent `u` to a child `v` in the DFS tree.
+/// - `Back(u, v)`: An edge from a node `u` to its ancestor `v` in the DFS tree. This indicates a cycle.
+/// - `ParentBack(u, v)`: A special case of a back edge where `v` is the direct parent of `u`.
+///   This is common in undirected graphs.
+/// - `Foward(u, v)`: An edge from a node `u` to its descendant `v` that is not a tree edge.
+/// - `Cross(u, v)`: An edge between two nodes `u` and `v` such that neither is an ancestor of the other.
 #[derive(Debug)]
 pub enum Edge<Node> {
     Tree(Node, Node),
@@ -185,6 +246,33 @@ pub enum Edge<Node> {
     Cross(Node, Node),
 }
 
+/// An iterator that performs a depth-first search (DFS) and classifies the edges of the graph.
+///
+/// This iterator wraps a `DfsIter` and uses its events to classify each edge of the
+/// graph into one of the categories defined by the `Edge` enum. It yields an `Edge<Node>`
+/// for each edge encountered during the traversal.
+///
+/// # Examples
+///
+/// ```rust
+/// use graphs_algorithms::{Edge, Graph};
+/// use graphs_algorithms::graphs::AdjacencyList;
+///
+/// let mut graph = AdjacencyList::default();
+/// graph.add_node(0);
+/// graph.add_node(1);
+/// graph.add_node(2);
+/// graph.add_edge(0, 1);
+/// graph.add_edge(1, 2);
+/// graph.add_edge(2, 0); // Cycle
+///
+/// let mut edges_iter = graph.classify_edges(0);
+///
+/// assert!(matches!(edges_iter.next(), Some(Edge::Tree(0, 1))));
+/// assert!(matches!(edges_iter.next(), Some(Edge::Tree(1, 2))));
+/// assert!(matches!(edges_iter.next(), Some(Edge::Back(2, 0))));
+/// assert!(edges_iter.next().is_none());
+/// ```
 pub struct DfsEdgesIter<'a, Node, G>
 where
     G: Graph<Node>,
@@ -211,6 +299,31 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> DfsEdgesIter<'a, Node, G> {
         }
     }
 
+    /// Sets the `start_node` field of the inner `DfsIter` manually.
+    ///
+    /// This enables classifying edges from another components of a graph.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use graphs_algorithms::graphs::AdjacencyList;
+    /// use graphs_algorithms::{Edge, Graph};
+    ///
+    /// let mut graph = AdjacencyList::default();
+    /// graph.add_node(0);
+    /// graph.add_node(1);
+    /// graph.add_node(2);
+    /// graph.add_edge(0, 1);
+    /// graph.add_edge(2, 0);
+    ///
+    /// let mut iter = graph.classify_edges(0);
+    /// assert!(matches!(iter.next(), Some(Edge::Tree(0, 1))));
+    /// assert!(iter.next().is_none());
+    ///
+    /// iter.new_start(2);
+    /// assert!(matches!(iter.next(), Some(Edge::Cross(2, 0))));
+    /// assert!(iter.next().is_none());
+    /// ```
     pub fn new_start(&mut self, start: Node) {
         self.iter.new_start(start);
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -163,7 +163,7 @@ mod test {
     use crate::{DfsEvent, Graph, graphs::AdjacencyList};
 
     #[test]
-    fn test_dfs_with_cycle() {
+    fn dfs_with_cycle() {
         let mut g = AdjacencyList::default();
         g.add_node(0);
         g.add_node(1);
@@ -185,7 +185,7 @@ mod test {
     }
 
     #[test]
-    fn test_dfs_simple_path() {
+    fn dfs_simple_path() {
         let mut g = AdjacencyList::default();
         g.add_node(0);
         g.add_node(1);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -97,7 +97,7 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> DfsIter<'a, Node, G> {
         }
     }
 
-    fn _new_start(&mut self, start: Node) {
+    pub fn new_start(&mut self, start: Node) {
         self.start_node = Some(start)
     }
 }
@@ -117,8 +117,9 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for DfsIter<'a, Node, 
     type Item = DfsEvent<Node>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(start_node) = self.start_node.take() {
-            self.visited.insert(start_node);
+        if let Some(start_node) = self.start_node.take()
+            && self.visited.insert(start_node)
+        {
             self.stack
                 .push((start_node, self.graph.neighbors(start_node)));
             return Some(DfsEvent::Discover(start_node, None));
@@ -208,6 +209,10 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> DfsEdgesIter<'a, Node, G> {
             parent: HashMap::with_capacity(graph.order()),
             stack_hash: HashSet::with_capacity(graph.order()),
         }
+    }
+
+    pub fn new_start(&mut self, start: Node) {
+        self.iter.new_start(start);
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,13 +1,6 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
+use std::fmt::Debug;
 use std::hash::Hash;
-
-pub enum Edge<Node> {
-    Tree((Node, Node)),
-    Back((Node, Node)),
-    ParentBack((Node, Node)),
-    Foward((Node, Node)),
-    Cross((Node, Node)),
-}
 
 pub trait Graph<Node: Eq + Hash + Copy> {
     fn order(&self) -> usize;
@@ -52,44 +45,84 @@ pub trait Graph<Node: Eq + Hash + Copy> {
     {
         BfsIter::new(self, start)
     }
+}
 
-    fn dfs_edges(&self, start_nodes: &[Node]) -> DfsEdgesIter<'_, Node, Self>
-    where
-        Self: Sized,
-    {
-        DfsEdgesIter::new(self, start_nodes)
+pub trait UndirectedGraph<Node: Copy + Eq + Hash>: Graph<Node> {
+    fn add_undirected_edge(&mut self, n: Node, m: Node) {
+        self.add_edge(n, m);
+        self.add_edge(m, n);
+    }
+
+    fn remove_undirected_edge(&mut self, n: Node, m: Node) {
+        self.remove_edge(n, m);
+        self.remove_edge(m, n);
     }
 }
 
-pub struct DfsIter<'a, Node, G> {
+pub struct DfsIter<'a, Node, G>
+where
+    G: Graph<Node>,
+    Node: Eq + Hash + Copy,
+    Self: 'a,
+{
     graph: &'a G,
-    stack: Vec<Node>,
+    stack: Vec<(Node, G::Neighbors<'a>)>,
     visited: HashSet<Node>,
+    start_node: Option<Node>,
 }
 
 impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> DfsIter<'a, Node, G> {
     fn new(graph: &'a G, start: Node) -> Self {
-        let mut visited = HashSet::with_capacity(graph.order());
-        visited.insert(start);
         Self {
             graph,
-            stack: vec![start],
-            visited,
+            stack: vec![],
+            visited: HashSet::with_capacity(graph.order()),
+            start_node: Some(start),
         }
+    }
+
+    fn _new_start(&mut self, start: Node) {
+        self.start_node = Some(start)
     }
 }
 
-impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for DfsIter<'a, Node, G> {
-    type Item = Node;
+#[derive(Debug)]
+pub enum DfsEvent<Node> {
+    /// A node is discovered for the first time.
+    /// The Option<Node> is the parent in the DFS tree (None for the start Node).
+    Discover(Node, Option<Node>),
+    /// All descendants of a node have been visited.
+    Finish(Node),
+    /// A non-tree edge is found from the first node to the second.
+    NonTreeEdge(Node, Node),
+}
+
+impl<'a, Node: Eq + Hash + Copy + Debug, G: Graph<Node>> Iterator for DfsIter<'a, Node, G> {
+    type Item = DfsEvent<Node>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let node = self.stack.pop()?;
-        for neighbor in self.graph.neighbors(node) {
-            if self.visited.insert(neighbor) {
-                self.stack.push(neighbor);
+        if let Some(start_node) = self.start_node.take() {
+            self.visited.insert(start_node);
+            self.stack
+                .push((start_node, self.graph.neighbors(start_node)));
+            return Some(DfsEvent::Discover(start_node, None));
+        }
+        if let Some((node, mut neighbors)) = self.stack.pop() {
+            if let Some(neighbor) = neighbors.next() {
+                self.stack.push((node, neighbors));
+
+                if self.visited.insert(neighbor) {
+                    self.stack.push((neighbor, self.graph.neighbors(neighbor)));
+                    return Some(DfsEvent::Discover(neighbor, Some(node)));
+                } else {
+                    return Some(DfsEvent::NonTreeEdge(node, neighbor));
+                }
+            } else {
+                return Some(DfsEvent::Finish(node));
             }
         }
-        Some(node)
+
+        None
     }
 }
 
@@ -125,100 +158,61 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for BfsIter<'a, Node, 
     }
 }
 
-pub struct DfsEdgesIter<'a, Node, G> {
-    graph: &'a G,
-    visited: HashSet<Node>,
-    discovery: HashMap<Node, usize>,
-    finish: HashMap<Node, usize>,
-    time: usize,
-    stack_hash: HashSet<Node>,
-    pending_edges: VecDeque<Edge<Node>>,
-}
+#[cfg(test)]
+mod test {
+    use crate::{DfsEvent, Graph, graphs::AdjacencyList};
 
-impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> DfsEdgesIter<'a, Node, G> {
-    /// Performs a depth-first search (DFS) starting from the given nodes,
-    /// recording discovery and finish times for each visited node.
-    pub fn times(
-        &mut self,
-        start_nodes: &[Node],
-    ) -> (&HashMap<Node, usize>, &HashMap<Node, usize>) {
-        for &n in start_nodes {
-            self.dfs(n, None);
-        }
-        (&self.discovery, &self.finish)
+    #[test]
+    fn test_dfs_with_cycle() {
+        let mut g = AdjacencyList::default();
+        g.add_node(0);
+        g.add_node(1);
+        g.add_node(2);
+        g.add_edge(0, 1);
+        g.add_edge(1, 2);
+        g.add_edge(2, 0); // Cycle
+
+        let mut dfs = g.dfs(0);
+
+        assert!(matches!(dfs.next(), Some(DfsEvent::Discover(0, None))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Discover(1, Some(0)))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Discover(2, Some(1)))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::NonTreeEdge(2, 0))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Finish(2))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Finish(1))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Finish(0))));
+        assert!(dfs.next().is_none());
     }
 
-    fn new(graph: &'a G, start_nodes: &[Node]) -> Self {
-        let mut iter = Self {
-            graph,
-            visited: HashSet::with_capacity(graph.order()),
-            discovery: HashMap::with_capacity(graph.order()),
-            finish: HashMap::with_capacity(graph.order()),
-            time: 0,
-            stack_hash: HashSet::with_capacity(graph.order()),
-            pending_edges: VecDeque::with_capacity(graph.size()),
-        };
+    #[test]
+    fn test_dfs_simple_path() {
+        let mut g = AdjacencyList::default();
+        g.add_node(0);
+        g.add_node(1);
+        g.add_node(2);
+        g.add_edge(0, 1);
+        g.add_edge(1, 2);
 
-        for &n in start_nodes {
-            iter.dfs(n, None);
-        }
-        iter
+        let mut dfs = g.dfs(0);
+
+        assert!(matches!(dfs.next(), Some(DfsEvent::Discover(0, None))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Discover(1, Some(0)))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Discover(2, Some(1)))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Finish(2))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Finish(1))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Finish(0))));
+        assert!(dfs.next().is_none());
     }
 
-    fn dfs(&mut self, start: Node, parent: Option<Node>) {
-        self.visited.insert(start);
-        self.discovery.insert(start, self.time);
-        self.time += 1;
-        self.stack_hash.insert(start);
+    #[test]
+    fn single_node_dfs() {
+        let mut g = AdjacencyList::default();
+        g.add_node(0);
 
-        for neighbor in self.graph.neighbors(start) {
-            if !self.visited.contains(&neighbor) {
-                self.pending_edges.push_back(Edge::Tree((start, neighbor)));
-                self.dfs(neighbor, Some(start));
-            } else if self.stack_hash.contains(&neighbor) {
-                if Some(neighbor) == parent {
-                    self.pending_edges
-                        .push_back(Edge::ParentBack((start, neighbor)));
-                } else {
-                    self.pending_edges.push_back(Edge::Back((start, neighbor)));
-                }
-            } else if self.discovery[&start] < self.discovery[&neighbor] {
-                self.pending_edges
-                    .push_back(Edge::Foward((start, neighbor)));
-            } else {
-                self.pending_edges.push_back(Edge::Cross((start, neighbor)));
-            }
-        }
+        let mut dfs = g.dfs(0);
 
-        self.stack_hash.remove(&start);
-        self.finish.insert(start, self.time);
-        self.time += 1;
-    }
-}
-
-impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for DfsEdgesIter<'a, Node, G> {
-    type Item = Edge<Node>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.pending_edges.pop_front()
-    }
-}
-
-pub trait UndirectedGraph<Node: Copy + Eq + Hash>: Graph<Node> {
-    fn add_undirected_edge(&mut self, n: Node, m: Node) {
-        self.add_edge(n, m);
-        self.add_edge(m, n);
-    }
-
-    fn remove_undirected_edge(&mut self, n: Node, m: Node) {
-        self.remove_edge(n, m);
-        self.remove_edge(m, n);
-    }
-
-    fn dfs_tree_and_back_edges(&self, start_nodes: &[Node]) -> impl Iterator<Item = Edge<Node>>
-    where
-        Self: Sized,
-    {
-        DfsEdgesIter::new(self, start_nodes)
-            .filter(|edge| matches!(edge, Edge::Tree(_) | Edge::Back(_)))
+        assert!(matches!(dfs.next(), Some(DfsEvent::Discover(0, None))));
+        assert!(matches!(dfs.next(), Some(DfsEvent::Finish(0))));
+        assert!(dfs.next().is_none());
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -19,9 +19,6 @@ pub trait Graph<Node: Eq + Hash + Copy> {
         Node: 'a;
     fn neighbors<'a>(&'a self, n: Node) -> Self::Neighbors<'a>;
 
-    fn connected(&self) -> bool;
-    fn biconnected_components(&self) -> &[Vec<Node>];
-
     fn biparted(&self) -> bool;
 
     fn has_edge(&self, n: Node, m: Node) -> bool {
@@ -55,6 +52,10 @@ pub trait Graph<Node: Eq + Hash + Copy> {
 }
 
 pub trait UndirectedGraph<Node: Copy + Eq + Hash>: Graph<Node> {
+    fn connected(&self) -> bool;
+
+    fn biconnected_components(&self) -> &[Vec<Node>];
+
     fn add_undirected_edge(&mut self, n: Node, m: Node) {
         self.add_edge(n, m);
         self.add_edge(m, n);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -45,6 +45,13 @@ pub trait Graph<Node: Eq + Hash + Copy> {
     {
         BfsIter::new(self, start)
     }
+
+    fn classify_edges(&self, start: Node) -> DfsEdgesIter<'_, Node, Self>
+    where
+        Self: Sized,
+    {
+        DfsEdgesIter::new(self, start)
+    }
 }
 
 pub trait UndirectedGraph<Node: Copy + Eq + Hash>: Graph<Node> {
@@ -56,6 +63,15 @@ pub trait UndirectedGraph<Node: Copy + Eq + Hash>: Graph<Node> {
     fn remove_undirected_edge(&mut self, n: Node, m: Node) {
         self.remove_edge(n, m);
         self.remove_edge(m, n);
+    }
+
+    fn classify_undirected_edges<'a>(&'a self, start: Node) -> impl Iterator<Item = Edge<Node>>
+    where
+        Self: Sized,
+        Node: 'a,
+    {
+        DfsEdgesIter::new(self, start)
+            .filter(|edge| matches!(edge, Edge::Tree(_, _) | Edge::Back(_, _)))
     }
 }
 
@@ -97,7 +113,7 @@ pub enum DfsEvent<Node> {
     NonTreeEdge(Node, Node),
 }
 
-impl<'a, Node: Eq + Hash + Copy + Debug, G: Graph<Node>> Iterator for DfsIter<'a, Node, G> {
+impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for DfsIter<'a, Node, G> {
     type Item = DfsEvent<Node>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -107,6 +123,7 @@ impl<'a, Node: Eq + Hash + Copy + Debug, G: Graph<Node>> Iterator for DfsIter<'a
                 .push((start_node, self.graph.neighbors(start_node)));
             return Some(DfsEvent::Discover(start_node, None));
         }
+
         if let Some((node, mut neighbors)) = self.stack.pop() {
             if let Some(neighbor) = neighbors.next() {
                 self.stack.push((node, neighbors));
@@ -155,6 +172,90 @@ impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for BfsIter<'a, Node, 
             }
         }
         Some(node)
+    }
+}
+
+#[derive(Debug)]
+pub enum Edge<Node> {
+    Tree(Node, Node),
+    Back(Node, Node),
+    ParentBack(Node, Node),
+    Foward(Node, Node),
+    Cross(Node, Node),
+}
+
+pub struct DfsEdgesIter<'a, Node, G>
+where
+    G: Graph<Node>,
+    Node: Eq + Hash + Copy,
+    Self: 'a,
+{
+    iter: DfsIter<'a, Node, G>,
+    time: usize,
+    discovery: HashMap<Node, usize>,
+    finish: HashMap<Node, usize>,
+    parent: HashMap<Node, Node>,
+    stack_hash: HashSet<Node>,
+}
+
+impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> DfsEdgesIter<'a, Node, G> {
+    fn new(graph: &'a G, start: Node) -> Self {
+        Self {
+            iter: DfsIter::new(graph, start),
+            time: 0,
+            discovery: HashMap::with_capacity(graph.order()),
+            finish: HashMap::with_capacity(graph.order()),
+            parent: HashMap::with_capacity(graph.order()),
+            stack_hash: HashSet::with_capacity(graph.order()),
+        }
+    }
+}
+
+impl<'a, Node: Eq + Hash + Copy, G: Graph<Node>> Iterator for DfsEdgesIter<'a, Node, G> {
+    type Item = Edge<Node>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(event) = self.iter.next() {
+                match event {
+                    DfsEvent::Discover(node, maybe_parent) => {
+                        self.stack_hash.insert(node);
+                        self.discovery.insert(node, self.time);
+                        self.time += 1;
+                        if let Some(parent) = maybe_parent {
+                            self.parent.insert(node, parent);
+                            return Some(Edge::Tree(parent, node));
+                        }
+                    }
+                    DfsEvent::Finish(node) => {
+                        self.stack_hash.remove(&node);
+                        self.finish.insert(node, self.time);
+                        self.time += 1;
+                    }
+                    DfsEvent::NonTreeEdge(node, neighbor) => {
+                        if self.stack_hash.contains(&neighbor) {
+                            if self
+                                .parent
+                                .get(&node)
+                                .is_some_and(|&parent| parent == neighbor)
+                            {
+                                return Some(Edge::ParentBack(node, neighbor));
+                            } else {
+                                return Some(Edge::Back(node, neighbor));
+                            }
+                        } else if self.discovery.get(&node).is_some_and(|t1| {
+                            self.discovery.get(&neighbor).is_some_and(|t2| t1 < t2)
+                        }) {
+                            return Some(Edge::Foward(node, neighbor));
+                        } else {
+                            return Some(Edge::Cross(node, neighbor));
+                        }
+                    }
+                }
+            } else {
+                return None;
+            }
+        }
     }
 }
 

--- a/src/incidence_matrix.rs
+++ b/src/incidence_matrix.rs
@@ -30,4 +30,31 @@ impl IncidenceMatrix {
     pub fn from_adjacency_list(_list: &AdjacencyList) -> Self {
         todo!()
     }
+
+    pub fn node_degree(&self, vertex: usize) -> usize {
+        if self.0.is_empty() || vertex >= self.0[0].len() {
+            return 0;
+        }
+
+        self.0.iter().filter(|row| row[vertex] != 0).count() / 2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_degree_incidence_matrix() {
+        // Grafo: 0 ── 1
+        //        │
+        //        2
+        let matrix = AdjacencyMatrix(vec![vec![0, 1, 1], vec![1, 0, 0], vec![1, 0, 0]]);
+
+        let incidence = IncidenceMatrix::from_adjacency_matrix(&matrix);
+
+        assert_eq!(incidence.node_degree(0), 2);
+        assert_eq!(incidence.node_degree(1), 1);
+        assert_eq!(incidence.node_degree(2), 1);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod adjacency_matrix;
 mod incidence_matrix;
 
 pub use graph::DfsEvent;
+pub use graph::Edge;
 pub use graph::Graph;
 pub use graph::UndirectedGraph;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod adjacency_list;
 mod adjacency_matrix;
 mod incidence_matrix;
 
-pub use graph::Edge;
+pub use graph::DfsEvent;
 pub use graph::Graph;
 pub use graph::UndirectedGraph;
 


### PR DESCRIPTION
- **refactor!(DfsIter): make the iterator based on dfs events instead of node discover**
- **style(graph): rename tests to match codebase style**
- **feat(dfs): add classify edges implementation for new dfs iterator**
- **test(bench): update benchmark to match new dfs solution**
- **feat(dfs): add the possibility to add a new start to the iterator**
- **refactor(adjacency_list): swaps the Box iterator for a concrete one**
- **docs(dfs): add documentation to dfs iterators and methods**
- **refactor(graph): move `connected` and `biconnected_components` methods to `UndirectedGraphs`**
